### PR TITLE
Fixed supervisor service restart

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -64,7 +64,7 @@
   register: supervisor_zookeeper
 
 - name: restart supervisor
-  service: name=supervisor state=restarted
+  service: name=supervisor state=restarted sleep=3
   when: supervisor_zookeeper | changed
 
 - name: restart zookeeper


### PR DESCRIPTION
The supervisor service does not behave like a good service:
In case of a restart it might not work (does not work on a first install) stop and start with a delay are required.
